### PR TITLE
Use unicode code point instead of character.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function(){
             }
 
             if (err !== null) {
-                gutil.log('gulp-jasmine2-phantomjs: ' + gutil.colors.red("✖ ") + 'Assertions failed in ' + gutil.colors.blue(file.relative));
+                gutil.log('gulp-jasmine2-phantomjs: ' + gutil.colors.red("\u2716 ") + 'Assertions failed in ' + gutil.colors.blue(file.relative));
                 this.emit('error', new gutil.PluginError('gulp-jasmine2-phantomjs', err));
             }
 


### PR DESCRIPTION
The reporter currently uses UTF8-encoded characters directly in its sources, which causes problems on other platforms such as Windows. Replacing it by an unicode code point should solve this issue.
