### PR TITLE
add ability to determine success or failue with pending tests

### DIFF
--- a/jasmine2-runner.js
+++ b/jasmine2-runner.js
@@ -170,9 +170,18 @@ function processPage(status, page, resultsKey) {
         };
         var getResults = function() {
             return page.evaluate(function(){
-                return document.getElementsByClassName("bar").length &&
-                       document.getElementsByClassName("bar")[0].innerHTML.match(/(\d+) spec.* (\d+) failure.*/) ||
-                       ["Unable to determine success or failure."];
+                var bar = document.getElementsByClassName("bar");
+                if(!bar.length){
+                    return ["Unable to determine success or failure."];
+                }
+                var regex = /(\d+) spec.* (\d+) failure.*/;
+                if(bar.length > 1){
+                    console.log("you may have some pending tests!", bar[0].innerHTML);
+                    return bar[1].innerHTML.match(regex);
+                }
+                else{
+                    return bar[0].innerHTML.match(regex);
+                }                
             });
         };
         var timeout = 30000;

--- a/jasmine2-runner.js
+++ b/jasmine2-runner.js
@@ -170,18 +170,22 @@ function processPage(status, page, resultsKey) {
         };
         var getResults = function() {
             return page.evaluate(function(){
-                var bar = document.getElementsByClassName("bar");
-                if(!bar.length){
-                    return ["Unable to determine success or failure."];
-                }
+
+                var passed = document.getElementsByClassName("bar passed");
+                var failed = document.getElementsByClassName("bar failed");
+                var pending = document.getElementsByClassName("bar skipped");
+
                 var regex = /(\d+) spec.* (\d+) failure.*/;
-                if(bar.length > 1){
-                    console.log("you may have some pending tests!", bar[0].innerHTML);
-                    return bar[1].innerHTML.match(regex);
+                if(pending.length > 0){
+                    console.log("you have some pending tests! ", pending[0].innerHTML);
                 }
-                else{
-                    return bar[0].innerHTML.match(regex);
-                }                
+                if(failed.length > 0){
+                    return failed[0].innerHTML.match(regex);
+                }
+                if(passed.length > 0){
+                    return passed[0].innerHTML.match(regex);
+                }
+                return ["Unable to determine success or failure."];
             });
         };
         var timeout = 30000;


### PR DESCRIPTION
I had some specs with temporarily disabled tests (using `xdescribe`).  I kept getting the "unable to determine success or failure" message.  The PR fixes that issue for me, and gives a little bit of a warning to the user.  
