### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 gulp-jasmine2-phantomjs
 =======================
 
-Use this plugin to run HTML spec files with Jasmine 2.0 specs. Currently, you must use this plugin in conjuction with the JUnitXmlReporter in [jasmine2-junit](https://github.com/sandermak/jasmine2-junit). This reporter generates JUnit XML reports to be used in a CI build. 
+Use this plugin to run HTML spec files with Jasmine 2.0 specs. Currently, you must use this plugin in conjunction with the JUnitXmlReporter in [jasmine2-junit](https://github.com/sandermak/jasmine2-junit). This reporter generates JUnit XML reports to be used in a CI build. 
 
 The plugin shows success/failure counts on the console. Specs will be run using PhantomJS.
 


### PR DESCRIPTION
@sandermak, I've corrected a typographical error in the documentation of the [gulp-jasmine2-phantomjs](https://github.com/sandermak/gulp-jasmine2-phantomjs) project. Specifically, I've changed conjuction to conjunction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.